### PR TITLE
JitPack build: Use latest Maven and Java 21

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+before_install:
+  - sdk install java 21-tem
+  - sdk use java 21-tem
+  - sdk install maven


### PR DESCRIPTION
Related: https://github.com/multiformats/java-multibase/pull/33

In this PR, I changed JitPack's settings to use the latest Maven and use java 21 LTS for compilation (project is still targeted for Java 11).

After my changes, the project is building successfully: https://jitpack.io/com/github/mk868/java-multiaddr/jitpack-build-24a611efc5-1/build.log